### PR TITLE
update css b3nding to support space-separated composed classnames

### DIFF
--- a/b3ndings/core.js
+++ b/b3ndings/core.js
@@ -41,8 +41,9 @@ module.exports = [
     }, {
         name: 'css',
         update : function (bindingData) {
+            var cl = classList(this);
             forEach(bindingData, function (v, k) {
-                classList(this)[v ? 'add' : 'remove'](k);
+                cl[v ? 'add' : 'remove'].apply(cl, k.split(' '));
             }, this);
         }
     }, {


### PR DESCRIPTION
the `classList` module supports simultaneous addition/removal of multiple classes, but requires them to be passed as separate arguments.

however, composing multiple local css maps results in space-separated class names:

```
{ class-name: localized-class-name-foo localized-class-name-bar }
```

this PR allows `b3nd` to accept `composeClassNames` output values without additional modification.
